### PR TITLE
add maxscale to maxadmin users

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ RUN mkdir -p /etc/maxscale.d \
     && cp /etc/maxscale.cnf.template /etc/maxscale.d/maxscale.cnf \
     && ln -sf /etc/maxscale.d/maxscale.cnf /etc/maxscale.cnf \
     && chown root:maxscale /etc/maxscale.d/maxscale.cnf \
-    && chmod g+w /etc/maxscale.d/maxscale.cnf
+    && chmod g+w /etc/maxscale.d/maxscale.cnf \
+    && echo '[{"name": "root", "account": "admin", "password": ""}, {"name": "maxscale", "account": "admin", "password": ""}]' > /var/lib/maxscale/maxadmin-users
 
 # VOLUME for custom configuration
 VOLUME ["/etc/maxscale.d"]


### PR DESCRIPTION
Sorry, I kind of stuck with this issue and forgot to set my last PR to WIP.

This line is needed to allow the user which is set (and forced to be used by maxscale itself) to configure anything threw the maxadmin cli (e.g. add additional users)